### PR TITLE
CHECKOUT-2450: Fix `Reducer` and `Action` type definitions

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,5 @@
-export default interface Action<TPayload = any, TMeta = any> {
-    type: string;
+export default interface Action<TPayload = any, TMeta = any, TType extends string = string> {
+    type: TType;
     error?: boolean;
     meta?: TMeta;
     payload?: TPayload;

--- a/src/combine-reducers.spec.ts
+++ b/src/combine-reducers.spec.ts
@@ -7,7 +7,7 @@ describe('combineReducers()', () => {
         const state = { foo: 'FOO', bar: 'BAR' };
         const action = { type: 'ACTION' };
 
-        const reducer = combineReducers({
+        const reducer = combineReducers<{ foo: string, bar: string }>({
             foo: fooReducer,
             bar: barReducer,
         });

--- a/src/combine-reducers.ts
+++ b/src/combine-reducers.ts
@@ -2,11 +2,11 @@ import { assign } from 'lodash';
 import Action from './action';
 import Reducer from './reducer';
 
-export default function combineReducers<TState, TAction extends Action>(
+export default function combineReducers<TState, TAction extends Action = Action>(
     reducers: ReducerMap<TState, TAction>
 ): Reducer<TState, TAction> {
     return (state, action) =>
-        Object.keys(reducers).reduce((result: TState, key) => {
+        Object.keys(reducers).reduce((result, key) => {
             const reducer = reducers[key as keyof TState];
             const currentState = state ? state[key as keyof TState] : undefined;
             const newState = reducer(currentState, action);
@@ -16,9 +16,9 @@ export default function combineReducers<TState, TAction extends Action>(
             }
 
             return assign({}, result, { [key]: newState });
-        }, state);
+        }, state || {} as TState);
 }
 
-export type ReducerMap<TState, TAction extends Action> = {
-    [Key in keyof TState]: Reducer<TState[Key] | undefined, TAction>;
+export type ReducerMap<TState, TAction extends Action = Action> = {
+    [Key in keyof TState]: Reducer<TState[Key], TAction>;
 };

--- a/src/compose-reducers.ts
+++ b/src/compose-reducers.ts
@@ -2,7 +2,7 @@ import { curryRight, flowRight } from 'lodash';
 import Action from './action';
 import Reducer from './reducer';
 
-export default function composeReducers<TState, TAction extends Action>(
+export default function composeReducers<TState, TAction extends Action = Action>(
     ...reducers: Array<Reducer<Partial<TState>, TAction>>
 ): Reducer<TState, TAction> {
     return (state, action) =>

--- a/src/create-action.ts
+++ b/src/create-action.ts
@@ -1,11 +1,11 @@
 import { omitBy } from 'lodash';
 import Action from './action';
 
-export default function createAction<TPayload, TMeta>(
-    type: string,
+export default function createAction<TPayload, TMeta, TType extends string>(
+    type: TType,
     payload?: TPayload,
     meta?: TMeta
-): Action<TPayload, TMeta> {
+): Action<TPayload, TMeta, TType> {
     if (typeof type !== 'string' || type === '') {
         throw new Error('`type` must be a string');
     }

--- a/src/create-data-store.ts
+++ b/src/create-data-store.ts
@@ -3,8 +3,8 @@ import combineReducers, { ReducerMap } from './combine-reducers';
 import DataStore, { DataStoreOptions } from './data-store';
 import Reducer from './reducer';
 
-export default function createDataStore<TState, TAction extends Action, TTransformedState = TState>(
-    reducer: Reducer<Partial<TState>, TAction> | ReducerMap<Partial<TState>, TAction>,
+export default function createDataStore<TState, TAction extends Action = Action, TTransformedState = TState>(
+    reducer: Reducer<TState, TAction> | ReducerMap<TState, TAction>,
     initialState?: Partial<TState>,
     options?: Partial<DataStoreOptions<TState, TAction, TTransformedState>>
 ): DataStore<TState, TAction, TTransformedState> {

--- a/src/create-error-action.ts
+++ b/src/create-error-action.ts
@@ -1,11 +1,11 @@
 import Action from './action';
 import createAction from './create-action';
 
-export default function createErrorAction<TPayload, TMeta>(
-    type: string,
+export default function createErrorAction<TPayload, TMeta, TType extends string>(
+    type: TType,
     payload?: TPayload,
     meta?: TMeta
-): Action<TPayload, TMeta> {
+): Action<TPayload, TMeta, TType> {
     return {
         ...createAction(type, payload, meta),
         error: true,

--- a/src/dispatchable-data-store.ts
+++ b/src/dispatchable-data-store.ts
@@ -3,7 +3,7 @@ import Action from './action';
 import ThunkAction from './thunk-action';
 import ReadableDataStore from './readable-data-store';
 
-export default interface DispatchableDataStore<TTransformedState, TAction extends Action> extends ReadableDataStore<TTransformedState> {
+export default interface DispatchableDataStore<TTransformedState, TAction extends Action = Action> extends ReadableDataStore<TTransformedState> {
     dispatch: <TDispatchAction extends TAction>(
         action: DispatchableAction<TDispatchAction, TTransformedState>,
         options?: DispatchOptions

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,5 +1,5 @@
 import Action from './action';
 
-type Reducer<TState, TAction extends Action> = (state: TState, action: TAction) => TState;
+type Reducer<TState, TAction extends Action = Action> = (state: TState | undefined, action: TAction) => TState;
 
 export default Reducer;


### PR DESCRIPTION
## What?
* Fix `Reducer` and `Action` type definitions.

## Why?
* So that you get proper type hinting when you combine / compose reducers or create actions.

## Testing / Proof
* Unit

@bigcommerce/frontend
