### PR TITLE
CHECKOUT-2450: `combineReducers` and `composeReducers` should only return new instance if different in value

### DIFF
--- a/src/combine-reducers.spec.ts
+++ b/src/combine-reducers.spec.ts
@@ -19,4 +19,16 @@ describe('combineReducers()', () => {
         expect(fooReducer).toHaveBeenCalledWith(state.foo, action);
         expect(barReducer).toHaveBeenCalledWith(state.bar, action);
     });
+
+    it('returns new instance only if different in value', () => {
+        const state = { foo: { name: 'FOO' }, bar: { name: 'BAR' } };
+        const reducer = combineReducers({
+            foo: (state, action) => action.type === 'UPDATE' ? { name: action.payload } : { ...state },
+            bar: (state) => ({ ...state }),
+        });
+
+        expect(reducer(state, { type: 'NOOP' })).toBe(state);
+        expect(reducer(state, { type: 'UPDATE', payload: 'Hello' })).not.toBe(state);
+        expect(reducer(state, { type: 'UPDATE', payload: 'Hello' }).bar).toBe(state.bar);
+    });
 });

--- a/src/combine-reducers.ts
+++ b/src/combine-reducers.ts
@@ -1,4 +1,4 @@
-import { assign } from 'lodash';
+import { assign, isEqual } from 'lodash';
 import Action from './action';
 import Reducer from './reducer';
 
@@ -11,7 +11,7 @@ export default function combineReducers<TState, TAction extends Action>(
             const currentState = state ? state[key as keyof TState] : undefined;
             const newState = reducer(currentState, action);
 
-            if (currentState === newState && result) {
+            if (isEqual(currentState, newState) && result) {
                 return result;
             }
 

--- a/src/compose-reducers.spec.ts
+++ b/src/compose-reducers.spec.ts
@@ -42,4 +42,15 @@ describe('composeReducers()', () => {
 
         expect(reducer(initialState, { type: 'APPEND' })).toEqual('foobar');
     });
+
+    it('returns new instance only if different in value', () => {
+        const reducer = composeReducers(
+            (state, action) => action.type === 'UPDATE' ? { name: action.payload } : { ...state },
+            (state, action) => action.type === 'UPDATE' ? { name: action.payload } : { ...state }
+        );
+        const initialState = { name: 'FOO' };
+
+        expect(reducer(initialState, { type: 'NOOP' })).toBe(initialState);
+        expect(reducer(initialState, { type: 'UPDATE', payload: 'Hello' })).not.toBe(initialState);
+    });
 });

--- a/src/compose-reducers.ts
+++ b/src/compose-reducers.ts
@@ -1,13 +1,16 @@
-import { curryRight, flowRight } from 'lodash';
+import { curryRight, flowRight, isEqual } from 'lodash';
 import Action from './action';
 import Reducer from './reducer';
 
 export default function composeReducers<TState, TAction extends Action>(
     ...reducers: Array<Reducer<Partial<TState>, TAction>>
 ): Reducer<TState, TAction> {
-    return (state, action) =>
-        flowRight.apply(
+    return (state, action) => {
+        const newState = flowRight.apply(
             null,
             reducers.map(reducer => curryRight(reducer)(action))
         )(state);
+
+        return isEqual(state, newState) ? state : newState;
+    };
 }


### PR DESCRIPTION
## What?
* Do a deep comparison when combining or composing reducers.
* Only return a new state if it is different to the existing state by value.

## Why?
* So it is easier to track changes when using the library, as you can just do simple equality comparison.
* We want the behaviour of a combined reducer to be consistent with a non-combined reducer.

## Testing / Proof
* Unit

@bigcommerce/frontend
