### PR TITLE
CHECKOUT-3027: Fix thunk actions not getting dispatched in separate queues

### DIFF
--- a/src/data-store.ts
+++ b/src/data-store.ts
@@ -182,7 +182,7 @@ export default class DataStore<TState, TAction extends Action = Action, TTransfo
         thunkAction: ThunkAction<TDispatchAction, TTransformedState>,
         options: DispatchOptions = {}
     ): Promise<TTransformedState> {
-        return this._dispatchObservableAction(thunkAction(this));
+        return this._dispatchObservableAction(thunkAction(this), options);
     }
 
     private _getDispatcher(queueId: string = 'default'): Dispatcher<TAction> {


### PR DESCRIPTION
## What?
* Pass `options` when dispatching thunk actions.

## Why?
* Otherwise, we can't dispatch thunk actions in a separate queue.

## Testing / Proof
* Unit

@bigcommerce/frontend
