### PR TITLE
CHECKOUT-3790: Allow `composeReducers` function to accept reducers of different type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ import { createDataStore } from '@bigcommerce/data-store';
 
 const reducer = (state, action) => {
     switch (action.type) {
-        case 'INCREMENT':
-            return { ...state, count: state.count + 1 };
+    case 'INCREMENT':
+        return { ...state, count: state.count + 1 };
 
-        case 'UPDATE_COUNT':
-            return { ...state, count: action.payload };
+    case 'UPDATE_COUNT':
+        return { ...state, count: action.payload };
 
-        default:
-            return state;
+    default:
+        return state;
     }
 };
 

--- a/src/compose-reducers.spec.ts
+++ b/src/compose-reducers.spec.ts
@@ -44,6 +44,17 @@ describe('composeReducers()', () => {
         expect(reducer(initialState, { type: 'APPEND' })).toEqual('foobar');
     });
 
+    it('composes reducers that handle different input type', () => {
+        const reducer = composeReducers(
+            barReducer,
+            fooReducer,
+            (state: string | number, action) => typeof state === 'string' ? state : `${state}`
+        );
+        const initialState = 123;
+
+        expect(reducer(initialState, { type: 'APPEND' })).toEqual('123foobar');
+    });
+
     it('returns new instance only if different in value', () => {
         const reducer = composeReducers(
             (state, action) => action.type === 'UPDATE' ? { name: action.payload } : { ...state },

--- a/src/compose-reducers.ts
+++ b/src/compose-reducers.ts
@@ -34,7 +34,9 @@ export default function composeReducers<TState, TAction extends Action = Action>
 ): Reducer<TState, TAction> {
     return (state, action) => {
         const newState = flowRight(
-            reducers.map(reducer => curryRight(reducer)(action))
+            reducers
+                .filter(reducer => reducer.length === 2)
+                .map(reducer => curryRight(reducer)(action))
         )(state);
 
         return isEqual(state, newState) ? state : newState;

--- a/src/compose-reducers.ts
+++ b/src/compose-reducers.ts
@@ -3,12 +3,37 @@ import { curryRight, flowRight, isEqual } from 'lodash';
 import Action from './action';
 import Reducer from './reducer';
 
+export default function composeReducers<TState, TStateA, TAction extends Action = Action>(
+    reducerA: (state: TStateA, action: TAction) => TState,
+    reducerB: (state: TState, action: TAction) => TStateA
+): Reducer<TState, TAction>;
+
+export default function composeReducers<TState, TStateA, TStateB, TAction extends Action = Action>(
+    reducerA: (state: TStateA, action: TAction) => TState,
+    reducerB: (state: TStateB, action: TAction) => TStateA,
+    reducerC: (state: TState, action: TAction) => TStateB
+): Reducer<TState, TAction>;
+
+export default function composeReducers<TState, TStateA, TStateB, TStateC, TAction extends Action = Action>(
+    reducerA: (state: TStateA, action: TAction) => TState,
+    reducerB: (state: TStateB, action: TAction) => TStateA,
+    reducerC: (state: TStateC, action: TAction) => TStateB,
+    reducerD: (state: TState, action: TAction) => TStateC
+): Reducer<TState, TAction>;
+
+export default function composeReducers<TState, TStateA, TStateB, TStateC, TStateD, TAction extends Action = Action>(
+    reducerA: (state: TStateA, action: TAction) => TState,
+    reducerB: (state: TStateB, action: TAction) => TStateA,
+    reducerC: (state: TStateC, action: TAction) => TStateB,
+    reducerD: (state: TStateD, action: TAction) => TStateC,
+    reducerE: (state: TState, action: TAction) => TStateD
+): Reducer<TState, TAction>;
+
 export default function composeReducers<TState, TAction extends Action = Action>(
     ...reducers: Array<Reducer<TState, TAction>>
 ): Reducer<TState, TAction> {
     return (state, action) => {
-        const newState = flowRight.apply(
-            null,
+        const newState = flowRight(
             reducers.map(reducer => curryRight(reducer)(action))
         )(state);
 


### PR DESCRIPTION
## What?
* Allow `composeReducers` function to accept reducers of different but compatible types.

## Why?
* Previously, we can only compose reducers of exactly the same type. But, in some cases, we want to be able to compose reducers of different but compatible types. For example:
```ts
// Create a reducer that accepts both string and number as its initial value
composeReducers(
    (state: string = '', action) => state,
    (state: string | number = 1, action) => typeof state === 'number' ? `${state}` : state
);
```

## Testing / Proof
* Travis

@bigcommerce/checkout 
