### PR TITLE
CHECKOUT-4137: Catch error if unable to freeze or perform check

### DIFF
--- a/src/deep-freeze.spec.ts
+++ b/src/deep-freeze.spec.ts
@@ -51,4 +51,15 @@ describe('deepFreeze()', () => {
 
         expect(deepFreeze(object)).toBe(object);
     });
+
+    it('catches type error when trying to freeze unsupported values', () => {
+        jest.spyOn(Object, 'freeze')
+            .mockImplementationOnce(() => {
+                throw TypeError();
+            });
+
+        const value = ['Foobar'];
+
+        expect(() => deepFreeze(value)).not.toThrowError();
+    });
 });

--- a/src/deep-freeze.ts
+++ b/src/deep-freeze.ts
@@ -4,17 +4,27 @@ export default function deepFreeze<T>(object: T[]): ReadonlyArray<T>;
 export default function deepFreeze<T extends object>(object: T): Readonly<T>;
 export default function deepFreeze<T>(object: T): T;
 export default function deepFreeze<T>(object: T[] | T): ReadonlyArray<T> | Readonly<T> | T {
-    if (Object.isFrozen(object) || (!Array.isArray(object) && !isPlainObject(object))) {
-        return object;
+    try {
+        if (Object.isFrozen(object) || (!Array.isArray(object) && !isPlainObject(object))) {
+            return object;
+        }
+
+        if (Array.isArray(object)) {
+            return Object.freeze(object.map(value => deepFreeze(value)));
+        }
+
+        return Object.freeze(Object.getOwnPropertyNames(object).reduce((result, key) => {
+            result[key as keyof T] = deepFreeze(object[key as keyof T]);
+
+            return result;
+        }, {} as T));
+    } catch (error) {
+        // Browsers that only support ES5 will throw `TypeError` when checking
+        // if a primitive value is frozen or trying to freeze a primitive value.
+        if (error instanceof TypeError) {
+            return object;
+        }
+
+        throw error;
     }
-
-    if (Array.isArray(object)) {
-        return Object.freeze(object.map(value => deepFreeze(value)));
-    }
-
-    return Object.freeze(Object.getOwnPropertyNames(object).reduce((result, key) => {
-        result[key as keyof T] = deepFreeze(object[key as keyof T]);
-
-        return result;
-    }, {} as T));
 }


### PR DESCRIPTION
## What?
* Catch error if unable to freeze or perform check

## Why?
* Browsers that only support ES5 will throw `TypeError` when checking if a primitive value is frozen or trying to freeze a primitive value. To make the behaviour consistent with ES6, we want to catch the error and simply return the value.

## Testing / Proof
* Unit

@bigcommerce/checkout 
