### PR TITLE
CHECKOUT-4272: Switch to do shallow comparison by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,11 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
       "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA=="
     },
+    "@types/shallowequal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/shallowequal/-/shallowequal-1.1.1.tgz",
+      "integrity": "sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ=="
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -78,6 +83,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2110,7 +2116,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2131,12 +2138,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2151,17 +2160,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2278,7 +2290,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2290,6 +2303,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2304,6 +2318,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2311,12 +2326,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2335,6 +2352,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2415,7 +2433,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2427,6 +2446,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2512,7 +2532,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2548,6 +2569,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2567,6 +2589,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2610,12 +2633,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4009,7 +4034,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -5449,6 +5475,11 @@
           }
         }
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.92",
+    "@types/shallowequal": "^1.1.1",
     "lodash": "^4.17.4",
     "rxjs": "^6.3.3",
+    "shallowequal": "^1.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/src/combine-reducers.ts
+++ b/src/combine-reducers.ts
@@ -4,15 +4,18 @@ import Action from './action';
 import Reducer from './reducer';
 
 export default function combineReducers<TState, TAction extends Action = Action>(
-    reducers: ReducerMap<TState, TAction>
+    reducers: ReducerMap<TState, TAction>,
+    options?: CombineReducersOptions
 ): Reducer<TState, TAction> {
+    const { equalityCheck = isEqual } = options || {};
+
     return (state, action) =>
         Object.keys(reducers).reduce((result, key) => {
             const reducer = reducers[key as keyof TState];
             const currentState = state ? state[key as keyof TState] : undefined;
             const newState = reducer(currentState, action);
 
-            if (isEqual(currentState, newState) && result) {
+            if (equalityCheck(currentState, newState) && result) {
                 return result;
             }
 
@@ -23,3 +26,7 @@ export default function combineReducers<TState, TAction extends Action = Action>
 export type ReducerMap<TState, TAction extends Action = Action> = {
     [Key in keyof TState]: Reducer<TState[Key], TAction>;
 };
+
+export interface CombineReducersOptions {
+    equalityCheck?(valueA: any, valueB: any): boolean;
+}

--- a/src/combine-reducers.ts
+++ b/src/combine-reducers.ts
@@ -1,4 +1,5 @@
-import { assign, isEqual } from 'lodash';
+import { assign } from 'lodash';
+import * as shallowEqual from 'shallowequal';
 
 import Action from './action';
 import Reducer from './reducer';
@@ -7,7 +8,7 @@ export default function combineReducers<TState, TAction extends Action = Action>
     reducers: ReducerMap<TState, TAction>,
     options?: CombineReducersOptions
 ): Reducer<TState, TAction> {
-    const { equalityCheck = isEqual } = options || {};
+    const { equalityCheck = shallowEqual } = options || {};
 
     return (state, action) =>
         Object.keys(reducers).reduce((result, key) => {

--- a/src/compose-reducers.ts
+++ b/src/compose-reducers.ts
@@ -1,4 +1,5 @@
-import { curryRight, flowRight, isEqual } from 'lodash';
+import { curryRight, flowRight } from 'lodash';
+import * as shallowEqual from 'shallowequal';
 
 import Action from './action';
 import Reducer from './reducer';
@@ -44,7 +45,7 @@ export default function composeReducers<TState, TAction extends Action = Action>
         options = { ...options, ...args[args.length - 1] };
     }
 
-    const { equalityCheck = isEqual } = options;
+    const { equalityCheck = shallowEqual } = options;
 
     return (state, action) => {
         const newState = flowRight(

--- a/src/compose-reducers.ts
+++ b/src/compose-reducers.ts
@@ -5,20 +5,23 @@ import Reducer from './reducer';
 
 export default function composeReducers<TState, TStateA, TAction extends Action = Action>(
     reducerA: (state: TStateA, action: TAction) => TState,
-    reducerB: (state: TState, action: TAction) => TStateA
+    reducerB: (state: TState, action: TAction) => TStateA,
+    options?: ComposeReducersOptions
 ): Reducer<TState, TAction>;
 
 export default function composeReducers<TState, TStateA, TStateB, TAction extends Action = Action>(
     reducerA: (state: TStateA, action: TAction) => TState,
     reducerB: (state: TStateB, action: TAction) => TStateA,
-    reducerC: (state: TState, action: TAction) => TStateB
+    reducerC: (state: TState, action: TAction) => TStateB,
+    options?: ComposeReducersOptions
 ): Reducer<TState, TAction>;
 
 export default function composeReducers<TState, TStateA, TStateB, TStateC, TAction extends Action = Action>(
     reducerA: (state: TStateA, action: TAction) => TState,
     reducerB: (state: TStateB, action: TAction) => TStateA,
     reducerC: (state: TStateC, action: TAction) => TStateB,
-    reducerD: (state: TState, action: TAction) => TStateC
+    reducerD: (state: TState, action: TAction) => TStateC,
+    options?: ComposeReducersOptions
 ): Reducer<TState, TAction>;
 
 export default function composeReducers<TState, TStateA, TStateB, TStateC, TStateD, TAction extends Action = Action>(
@@ -26,12 +29,23 @@ export default function composeReducers<TState, TStateA, TStateB, TStateC, TStat
     reducerB: (state: TStateB, action: TAction) => TStateA,
     reducerC: (state: TStateC, action: TAction) => TStateB,
     reducerD: (state: TStateD, action: TAction) => TStateC,
-    reducerE: (state: TState, action: TAction) => TStateD
+    reducerE: (state: TState, action: TAction) => TStateD,
+    options?: ComposeReducersOptions
 ): Reducer<TState, TAction>;
 
 export default function composeReducers<TState, TAction extends Action = Action>(
-    ...reducers: Array<Reducer<TState, TAction>>
+    ...args: any[]
 ): Reducer<TState, TAction> {
+    let reducers: Array<Reducer<TState, TAction>> = args;
+    let options: ComposeReducersOptions = {};
+
+    if (typeof args[args.length - 1] === 'object') {
+        reducers = args.slice(0, -1);
+        options = { ...options, ...args[args.length - 1] };
+    }
+
+    const { equalityCheck = isEqual } = options;
+
     return (state, action) => {
         const newState = flowRight(
             reducers
@@ -39,6 +53,10 @@ export default function composeReducers<TState, TAction extends Action = Action>
                 .map(reducer => curryRight(reducer)(action))
         )(state);
 
-        return isEqual(state, newState) ? state : newState;
+        return equalityCheck(state, newState) ? state : newState;
     };
+}
+
+export interface ComposeReducersOptions {
+    equalityCheck?(valueA: any, valueB: any): boolean;
 }

--- a/src/create-data-store.ts
+++ b/src/create-data-store.ts
@@ -12,5 +12,9 @@ export default function createDataStore<TState, TAction extends Action = Action,
         return new DataStore(reducer, initialState, options);
     }
 
-    return new DataStore(combineReducers(reducer), initialState, options);
+    return new DataStore(
+        combineReducers(reducer, { equalityCheck: options && options.equalityCheck }),
+        initialState,
+        options
+    );
 }

--- a/src/data-store.ts
+++ b/src/data-store.ts
@@ -1,4 +1,4 @@
-import { isEqual, merge } from 'lodash';
+import { merge } from 'lodash';
 import {
     defer,
     from,
@@ -22,6 +22,7 @@ import {
     skip,
     tap,
 } from 'rxjs/operators';
+import * as shallowEqual from 'shallowequal';
 
 import Action from './action';
 import deepFreeze from './deep-freeze';
@@ -51,7 +52,7 @@ export default class DataStore<TState, TAction extends Action = Action, TTransfo
         this._reducer = reducer;
         this._options = {
             actionTransformer: noopActionTransformer,
-            equalityCheck: isEqual,
+            equalityCheck: shallowEqual,
             shouldWarnMutation: true,
             stateTransformer: noopStateTransformer,
             ...options,


### PR DESCRIPTION
## What?
* Switch to do a shallow comparison between the previous and the new state by default.
* Add the ability to pass a custom equality check function if there is a need to override the default equality checkout behaviour.

## Why?
* If reducers only return a new state when there are changes to its subtree, we don't need to do a deep comparison between the new and the old state. We want to avoid doing a deep comparison as it could impact performance if the state tree is large and nested, and changes frequently. 

## Testing / Proof
* Unit

@bigcommerce/checkout
