### PR TITLE
CHECKOUT-4272: Only create new frozen objects if they are different from previous frozen objects

### DIFF
--- a/src/data-store.spec.ts
+++ b/src/data-store.spec.ts
@@ -319,10 +319,12 @@ describe('DataStore', () => {
 
         it('does not notify subscribers if current state has shallowly changed in reference but not in value', () => {
             const store = new DataStore(
-                (state = { data: { foobar: '' } }, action) => (
-                    action.type === 'SHALLOW' ? { ...state } : { ...state, data: { ...state.data } }
+                (state = { data: { foobar: '', message: '' } }, action) => (
+                    action.type === 'SHALLOW' ?
+                        { ...state } :
+                        { ...state, data: { ...state.data, message: action.payload } }
                 ),
-                { data: { foobar: 'foobar' } }
+                { data: { foobar: 'foobar', message: '' } }
             );
 
             const subscriber = jest.fn();
@@ -332,7 +334,7 @@ describe('DataStore', () => {
 
             expect(subscriber.mock.calls.length).toEqual(1);
 
-            store.dispatch({ type: 'DEEP' });
+            store.dispatch({ type: 'DEEP', payload: 'Hello world' });
 
             expect(subscriber.mock.calls.length).toEqual(2);
         });

--- a/src/data-store.ts
+++ b/src/data-store.ts
@@ -143,10 +143,13 @@ export default class DataStore<TState, TAction extends Action = Action, TTransfo
         action: TAction
     ): StateTuple<TState, TTransformedState> {
         try {
-            const newState = this._reducer(states.state, action);
-            const transformedState = this._options.shouldWarnMutation === false ?
-                this._options.stateTransformer(newState) :
-                this._options.stateTransformer(deepFreeze(newState));
+            const newState = this._options.shouldWarnMutation === false ?
+                this._reducer(states.state, action) :
+                deepFreeze(this._reducer(states.state, action), {
+                    equalityCheck: this._options.equalityCheck,
+                    previousValue: states.state,
+                });
+            const transformedState = this._options.stateTransformer(newState);
 
             return { state: newState, transformedState };
         } catch (error) {

--- a/src/deep-freeze.spec.ts
+++ b/src/deep-freeze.spec.ts
@@ -52,6 +52,13 @@ describe('deepFreeze()', () => {
         expect(deepFreeze(object)).toBe(object);
     });
 
+    it('does not return new object if previous object is equal to new', () => {
+        const newValue = { message: 'Foobar' };
+        const previousValue = deepFreeze({ message: 'Foobar' });
+
+        expect(deepFreeze(newValue, { previousValue })).toBe(previousValue);
+    });
+
     it('catches type error when trying to freeze unsupported values', () => {
         jest.spyOn(Object, 'freeze')
             .mockImplementationOnce(() => {

--- a/src/deep-freeze.ts
+++ b/src/deep-freeze.ts
@@ -1,20 +1,45 @@
 import { isPlainObject } from 'lodash';
+import * as shallowEqual from 'shallowequal';
 
-export default function deepFreeze<T>(object: T[]): ReadonlyArray<T>;
-export default function deepFreeze<T extends object>(object: T): Readonly<T>;
-export default function deepFreeze<T>(object: T): T;
-export default function deepFreeze<T>(object: T[] | T): ReadonlyArray<T> | Readonly<T> | T {
+export interface DeepFreezeOptions<T> {
+    previousValue?: T;
+    equalityCheck?(valueA: any, valueB: any): boolean;
+}
+
+export default function deepFreeze<T>(object: T[], options?: DeepFreezeOptions<T>): ReadonlyArray<T>;
+export default function deepFreeze<T extends object>(object: T, options?: DeepFreezeOptions<T>): Readonly<T>;
+export default function deepFreeze<T>(object: T, options?: DeepFreezeOptions<T>): T;
+export default function deepFreeze<T>(
+    object: T[] | T,
+    options?: DeepFreezeOptions<T>
+): ReadonlyArray<T> | Readonly<T> | T {
     try {
+        const { equalityCheck = shallowEqual, previousValue = null } = options || {};
+
+        if (equalityCheck(object, previousValue) && Object.isFrozen(previousValue)) {
+            return previousValue as T;
+        }
+
         if (Object.isFrozen(object) || (!Array.isArray(object) && !isPlainObject(object))) {
             return object;
         }
 
         if (Array.isArray(object)) {
-            return Object.freeze(object.map(value => deepFreeze(value)));
+            return Object.freeze(object.map((value, index) =>
+                deepFreeze(value, {
+                    equalityCheck,
+                    previousValue: Array.isArray(previousValue) ? previousValue[index] : undefined,
+                })
+            ));
         }
 
         return Object.freeze(Object.getOwnPropertyNames(object).reduce((result, key) => {
-            result[key as keyof T] = deepFreeze(object[key as keyof T]);
+            result[key as keyof T] = deepFreeze(object[key as keyof T], {
+                equalityCheck,
+                previousValue: previousValue && previousValue.hasOwnProperty(key) ?
+                    (previousValue as any)[key] :
+                    undefined,
+            });
 
             return result;
         }, {} as T));


### PR DESCRIPTION
## What?
Only create new frozen objects if they are different from the previous frozen objects.

## Why?
If we don't do the check, we'll be recursively creating new frozen objects when the `shouldWarnMutation` is on even when there's no need because the previous objects have not changed and have been frozen already.

## Testing / Proof
Unit

@bigcommerce/checkout 
