### PR TITLE
CHECKOUT-9450: Fix issue with ES6 as functions with default arguments no longer return length

### DIFF
--- a/src/compose-reducers.spec.ts
+++ b/src/compose-reducers.spec.ts
@@ -65,4 +65,45 @@ describe('composeReducers()', () => {
         expect(reducer(initialState, { type: 'NOOP' })).toBe(initialState);
         expect(reducer(initialState, { type: 'UPDATE', payload: 'Hello' })).not.toBe(initialState);
     });
+
+    it('composes multiple reducers without argument length', () => {
+        const fooReducerWithArgs = (...args: any[]) => {
+            const state = args[0];
+            const action = args[1];
+
+            switch (action.type) {
+            case 'FOO':
+                return 'foo';
+
+            case 'APPEND':
+                return `${state}foo`;
+
+            default:
+                return state;
+            }
+        };
+
+        const barReducerWithArgs = (...args: any[]) => {
+            const state = args[0];
+            const action = args[1];
+
+            switch (action.type) {
+            case 'BAR':
+                return 'bar';
+
+            case 'APPEND':
+                return `${state}bar`;
+
+            default:
+                return state;
+            }
+        };
+
+        const reducer = composeReducers(barReducerWithArgs, fooReducerWithArgs);
+        const initialState = '';
+
+        expect(reducer(initialState, { type: 'FOO' })).toEqual('foo');
+        expect(reducer(initialState, { type: 'BAR' })).toEqual('bar');
+        expect(reducer(initialState, { type: 'HELLO' })).toEqual('');
+    });
 });

--- a/src/compose-reducers.ts
+++ b/src/compose-reducers.ts
@@ -49,9 +49,7 @@ export default function composeReducers<TState, TAction extends Action = Action>
 
     return (state, action) => {
         const newState = flowRight(
-            reducers
-                .filter(reducer => reducer.length === 2)
-                .map(reducer => curryRight(reducer)(action))
+            reducers.map(reducer => curryRight(reducer, 2)(action))
         )(state);
 
         return equalityCheck(state, newState) ? state : newState;


### PR DESCRIPTION
## What/Why?
In ES6, `function.length` no longer includes parameters with default values. This change ensures that `composeReducers` continues to work by hard-coding the expected number of arguments based on the `Reducer` interface. See:
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters
* https://lodash.com/docs/#curryRight

## Testing / Proof
CircleCI

